### PR TITLE
Fix bug in topics tab of profile view controller

### DIFF
--- a/WomenWhoCode/ProfileViewController.swift
+++ b/WomenWhoCode/ProfileViewController.swift
@@ -251,15 +251,14 @@ extension ProfileViewController: UITableViewDataSource, UITableViewDelegate{
             } else {
                 cell.eventImageView.image = UIImage(named: "languages")
             }
+            cell.accessoryType = .None
             cell.eventDate.text = ""
             cell.eventLocation.text = ""
             cell.eventDescription.text = ""
-            cell.eventTag1.text = ""
-            cell.eventTag2.text = ""
-            cell.rsvpLabel.text = ""
+            cell.rsvpLabel.hidden = true
             cell.eventLocation.text = ""
-            cell.eventSpots.text = ""
-            cell.rsvpConfirmedLabel.text = ""
+            cell.eventSpots.hidden = true
+            cell.rsvpConfirmedLabel.hidden = true
             cell.backgroundColor = UIColor(hexString: topics[indexPath.row].hex_color!)
             
         }


### PR DESCRIPTION
Reusing eventCell2 in topics tab and since the UI has changed, the
corresponding code in ProfileViewController needs to be changed.
@mahagovind : I think it is better to use another nib instead of
reusing the event cell here.